### PR TITLE
Add SciCode example support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Note - this repo is under extremely active development. Hic sunt dracones, if no
 [] NMMO (active dev - do not attempt)
 [] Red (active dev)
 [] Verilog (maturing)
+[] SciCode (maturing)
 
 ...
 

--- a/src/examples/scicode/engine.py
+++ b/src/examples/scicode/engine.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+import json
+import uuid
+from pathlib import Path
+from typing import List, Dict, Any, Optional, Tuple
+from dataclasses import dataclass
+
+from datasets import load_dataset
+
+from src.stateful.engine import StatefulEngine, StatefulEngineSnapshot
+from src.environment.shared_engine import GetObservationCallable, InternalObservation
+from src.tasks.core import TaskInstance as BaseTaskInstance
+
+
+# --- Task Loading and Scoring -------------------------------------------------
+def load_tasks() -> List[Dict[str, Any]]:
+    """Load SciCode tasks from cache or HuggingFace."""
+    cache_path = Path(__file__).parent / "dataset" / "scicode.json"
+    if cache_path.exists():
+        with open(cache_path) as f:
+            return json.load(f)
+
+    ds = load_dataset("allenai/scicode", split="train")
+    tasks: List[Dict[str, Any]] = []
+    for ex in ds:
+        tasks.append(
+            {
+                "id": str(uuid.uuid4()),
+                "prompt": ex.get("prompt") or ex.get("question"),
+                "solution": ex.get("solution") or ex.get("answer"),
+                "category": ex.get("category"),
+                "difficulty": ex.get("difficulty"),
+            }
+        )
+
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(cache_path, "w") as f:
+        json.dump(tasks, f)
+
+    return tasks
+
+
+def score_response(response: str, gold: str) -> bool:
+    return response.strip() == gold.strip()
+
+
+# --- Engine States and Snapshot ----------------------------------------------
+@dataclass
+class SciCodePublicState:
+    problem_id: str
+    prompt: str
+    category: Optional[str]
+    difficulty: Optional[str]
+
+
+@dataclass
+class SciCodePrivateState:
+    solution: str
+    submitted_answer: Optional[str] = None
+    is_correct: Optional[bool] = None
+    terminated: bool = False
+
+
+@dataclass
+class SciCodeEngineSnapshot(StatefulEngineSnapshot):
+    task_instance_dict: Dict
+    current_problem_id: str
+
+
+# --- Observation Callables ----------------------------------------------------
+class SynthSciCodeObservationCallable(GetObservationCallable):
+    async def get_observation(
+        self, pub: SciCodePublicState, priv: SciCodePrivateState
+    ) -> InternalObservation:
+        obs = {
+            "problem_id": pub.problem_id,
+            "prompt": pub.prompt,
+            "category": pub.category,
+            "difficulty": pub.difficulty,
+            "terminated": priv.terminated,
+        }
+        if priv.submitted_answer is not None:
+            obs["submitted_answer"] = priv.submitted_answer
+            obs["is_correct"] = priv.is_correct
+        return obs
+
+
+# --- SciCode Engine -----------------------------------------------------------
+class SciCodeEngine(StatefulEngine):
+    def __init__(self, task_instance: BaseTaskInstance):
+        super().__init__()
+        self.task_instance = task_instance
+        self._all_tasks: List[Dict[str, Any]] = load_tasks()
+        self._task_lookup: Dict[str, Dict[str, Any]] = {
+            t["id"]: t for t in self._all_tasks
+        }
+
+        self.current_problem_id: Optional[str] = None
+        self.current_prompt: Optional[str] = None
+        self.current_solution: Optional[str] = None
+        self.current_category: Optional[str] = None
+        self.current_difficulty: Optional[str] = None
+
+        self.submitted_answer: Optional[str] = None
+        self.is_correct: Optional[bool] = None
+        self.terminated: bool = False
+
+    def _load_problem(self, problem_id: str) -> bool:
+        data = self._task_lookup.get(problem_id)
+        if not data:
+            return False
+        self.current_problem_id = data["id"]
+        self.current_prompt = data["prompt"]
+        self.current_solution = data["solution"]
+        self.current_category = data.get("category")
+        self.current_difficulty = data.get("difficulty")
+        self.submitted_answer = None
+        self.is_correct = None
+        self.terminated = False
+        return True
+
+    async def _reset_engine(
+        self, problem_id: Optional[str] = None
+    ) -> Tuple[SciCodePrivateState, SciCodePublicState]:
+        pid = problem_id or next(iter(self._task_lookup))
+        if not self._load_problem(pid):
+            raise ValueError(f"Problem {pid} not found")
+
+        pub = SciCodePublicState(
+            problem_id=self.current_problem_id,
+            prompt=self.current_prompt,
+            category=self.current_category,
+            difficulty=self.current_difficulty,
+        )
+        priv = SciCodePrivateState(solution=self.current_solution, terminated=False)
+        return priv, pub
+
+    async def _step_engine(
+        self, submitted_answer: str
+    ) -> Tuple[SciCodePrivateState, SciCodePublicState]:
+        if self.current_solution is None or self.current_problem_id is None:
+            raise RuntimeError("Engine not initialized")
+
+        self.submitted_answer = submitted_answer
+        self.is_correct = score_response(submitted_answer, self.current_solution)
+        self.terminated = True
+
+        pub = SciCodePublicState(
+            problem_id=self.current_problem_id,
+            prompt=self.current_prompt,
+            category=self.current_category,
+            difficulty=self.current_difficulty,
+        )
+        priv = SciCodePrivateState(
+            solution=self.current_solution,
+            submitted_answer=self.submitted_answer,
+            is_correct=self.is_correct,
+            terminated=True,
+        )
+        return priv, pub
+
+    async def _serialize_engine(self) -> SciCodeEngineSnapshot:
+        if not self.task_instance or not self.current_problem_id:
+            raise RuntimeError("Engine not initialized")
+        task_instance_dict = await self.task_instance.serialize()
+        return SciCodeEngineSnapshot(
+            task_instance_dict=task_instance_dict,
+            current_problem_id=self.current_problem_id,
+        )
+
+    @classmethod
+    async def _deserialize_engine(
+        cls, snapshot: SciCodeEngineSnapshot
+    ) -> "SciCodeEngine":
+        from examples.scicode.schema import SciCodeTaskInstance
+
+        task_instance = await SciCodeTaskInstance.deserialize(
+            snapshot.task_instance_dict
+        )
+        engine = cls(task_instance)
+        if not engine._load_problem(snapshot.current_problem_id):
+            raise ValueError(f"Problem {snapshot.current_problem_id} not found")
+        return engine

--- a/src/examples/scicode/environment.py
+++ b/src/examples/scicode/environment.py
@@ -1,0 +1,59 @@
+from typing import Optional, List
+
+from src.environment.shared_engine import GetObservationCallable, InternalObservation
+from src.stateful.core import StatefulEnvironment
+from src.environment.tools import EnvToolCall
+
+from examples.scicode.engine import (
+    SciCodeEngine,
+    SciCodePublicState,
+    SciCodePrivateState,
+    SciCodeEngineSnapshot,
+    SynthSciCodeObservationCallable,
+)
+from examples.scicode.schema import SciCodeTaskInstance
+from examples.scicode.tools import SubmitAnswerTool
+
+
+class SciCodeEnv(StatefulEnvironment):
+    def __init__(
+        self,
+        task_instance: SciCodeTaskInstance,
+        custom_step_obs: Optional[GetObservationCallable] = None,
+    ):
+        self.name = "SciCodeEnv"
+        self.task_instance = task_instance
+        self.custom_obs = custom_step_obs or SynthSciCodeObservationCallable()
+        self.engine = SciCodeEngine(task_instance)
+
+    async def initialize(self) -> InternalObservation:
+        priv, pub = await self.engine._reset_engine()
+        return await self.custom_obs.get_observation(pub, priv)
+
+    async def terminate(self) -> InternalObservation:
+        return {"terminated": True, "message": "Environment terminated"}
+
+    def validate_tool_calls(self, tool_calls: List[List[EnvToolCall]]) -> None:
+        if (
+            not tool_calls
+            or not tool_calls[0]
+            or not isinstance(tool_calls[0][0], SubmitAnswerTool)
+        ):
+            raise ValueError("Expected SubmitAnswerTool")
+
+    async def step(self, tool_calls: List[List[EnvToolCall]]) -> InternalObservation:
+        self.validate_tool_calls(tool_calls)
+        answer = tool_calls[0][0].answer  # type: ignore[attr-defined]
+        priv, pub = await self.engine._step_engine(answer)
+        return await self.custom_obs.get_observation(pub, priv)
+
+    async def checkpoint(self) -> InternalObservation:
+        snap = await self.engine._serialize_engine()
+        return snap.model_dump()
+
+    @classmethod
+    async def _deserialize_engine(cls, snapshot: SciCodeEngineSnapshot) -> "SciCodeEnv":
+        engine = await SciCodeEngine._deserialize_engine(snapshot)
+        env = cls(task_instance=engine.task_instance)
+        env.engine = engine
+        return env

--- a/src/examples/scicode/schema.py
+++ b/src/examples/scicode/schema.py
@@ -1,0 +1,38 @@
+from dataclasses import dataclass, asdict, fields
+from uuid import UUID
+from typing import Optional, Dict, Any
+
+from src.tasks.core import TaskInstance, TaskInstanceMetadata, Impetus, Intent
+
+
+@dataclass
+class SciCodeTaskInstanceMetadata(TaskInstanceMetadata):
+    category: Optional[str]
+    difficulty: Optional[str]
+    solution: str
+
+
+@dataclass
+class SciCodeTaskInstance(TaskInstance):
+    async def serialize(self) -> Dict[str, Any]:
+        data = asdict(self)
+        if "id" in data and isinstance(data["id"], UUID):
+            data["id"] = str(data["id"])
+        return data
+
+    @classmethod
+    async def deserialize(cls, data: Dict[str, Any]) -> "SciCodeTaskInstance":
+        if "id" in data:
+            try:
+                data["id"] = UUID(str(data["id"]))
+            except Exception:
+                pass
+        if "impetus" in data and isinstance(data["impetus"], dict):
+            data["impetus"] = Impetus(**data["impetus"])
+        if "intent" in data and isinstance(data["intent"], dict):
+            data["intent"] = Intent(**data["intent"])
+        if "metadata" in data and isinstance(data["metadata"], dict):
+            data["metadata"] = SciCodeTaskInstanceMetadata(**data["metadata"])
+        allowed = {f.name for f in fields(cls)}
+        filtered = {k: v for k, v in data.items() if k in allowed}
+        return cls(**filtered)

--- a/src/examples/scicode/taskset.py
+++ b/src/examples/scicode/taskset.py
@@ -1,0 +1,59 @@
+from dataclasses import dataclass
+from uuid import uuid4, UUID
+from typing import List
+
+from datasets import load_dataset
+
+from src.tasks.core import (
+    Task,
+    TaskInstance,
+    TaskInstanceMetadata,
+    TaskInstanceSet,
+    SplitInfo,
+    Impetus,
+    Intent,
+)
+from examples.scicode.schema import SciCodeTaskInstance, SciCodeTaskInstanceMetadata
+
+
+scicode_task = Task(
+    global_premises="Answer programming questions from the SciCode dataset",
+    global_constraints="",
+    global_objectives="Provide the correct code or explanation",
+    shared_env_params={},
+)
+
+
+async def create_scicode_taskset(max_instances: int = 100) -> TaskInstanceSet:
+    ds = load_dataset("allenai/scicode", split="train")
+    instances: List[SciCodeTaskInstance] = []
+    for i, ex in enumerate(ds):
+        if i >= max_instances:
+            break
+        inst_id = UUID(str(ex.get("id", uuid4()))) if ex.get("id") else uuid4()
+        impetus = Impetus(instructions="Solve the SciCode task.")
+        intent = Intent(rubric={}, gold_trajectories=None, gold_state_diff={})
+        metadata = SciCodeTaskInstanceMetadata(
+            category=ex.get("category"),
+            difficulty=ex.get("difficulty"),
+            solution=ex.get("solution") or ex.get("answer"),
+        )
+        instance = SciCodeTaskInstance(
+            id=inst_id,
+            impetus=impetus,
+            intent=intent,
+            metadata=metadata,
+            is_reproducible=True,
+            initial_engine_snapshot=None,
+        )
+        instances.append(instance)
+
+    split_info = SplitInfo(
+        val_instance_ids=set(), test_instance_ids=set(), _is_split_defined=False
+    )
+    return TaskInstanceSet(
+        name="SciCode TaskSet",
+        description="Tasks derived from the AllenAI SciCode dataset",
+        instances=instances,
+        split_info=split_info,
+    )

--- a/src/examples/scicode/tools.py
+++ b/src/examples/scicode/tools.py
@@ -1,0 +1,14 @@
+from src.environment.tools import EnvToolCall
+
+
+class SubmitAnswerTool(EnvToolCall):
+    """Simple wrapper holding the submitted answer."""
+
+    def __init__(self, answer: str):
+        # EnvToolCall inherits from Pydantic's BaseModel which forbids setting
+        # undeclared attributes via normal assignment. Use object.__setattr__
+        # to bypass validation as we just need a lightweight wrapper.
+        object.__setattr__(self, "answer", answer)
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        return f"SubmitAnswerTool(answer='{self.answer[:50]}...')"

--- a/tests/integration/test_scicode_env.py
+++ b/tests/integration/test_scicode_env.py
@@ -1,0 +1,73 @@
+import sys
+from pathlib import Path
+
+root = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(root / "src"))
+sys.path.insert(0, str(root))
+
+import asyncio
+from uuid import uuid4
+
+import pytest
+
+from examples.scicode.environment import SciCodeEnv
+from examples.scicode.schema import SciCodeTaskInstance, SciCodeTaskInstanceMetadata
+from examples.scicode.tools import SubmitAnswerTool
+from examples.scicode.engine import load_tasks as original_load_tasks
+from examples.scicode import engine as scicode_engine
+from src.tasks.core import Impetus, Intent
+
+
+@pytest.fixture(autouse=True)
+def patch_load_tasks(monkeypatch):
+    tasks = [
+        {
+            "id": "1",
+            "prompt": "What is 2 + 2?",
+            "solution": "4",
+            "category": "math",
+            "difficulty": "easy",
+        }
+    ]
+    monkeypatch.setattr(scicode_engine, "load_tasks", lambda: tasks)
+    yield tasks
+    monkeypatch.setattr(scicode_engine, "load_tasks", original_load_tasks)
+
+
+def make_instance(task):
+    metadata = SciCodeTaskInstanceMetadata(
+        category=task["category"],
+        difficulty=task["difficulty"],
+        solution=task["solution"],
+    )
+    impetus = Impetus(instructions="Solve the SciCode task.")
+    intent = Intent(rubric={}, gold_trajectories=None, gold_state_diff={})
+    return SciCodeTaskInstance(
+        id=uuid4(),
+        impetus=impetus,
+        intent=intent,
+        metadata=metadata,
+        is_reproducible=True,
+        initial_engine_snapshot=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_scicode_env_correct_answer(patch_load_tasks):
+    task = patch_load_tasks[0]
+    env = SciCodeEnv(make_instance(task))
+    obs = await env.initialize()
+    assert obs["prompt"] == task["prompt"]
+    obs = await env.step([[SubmitAnswerTool(answer="4")]])
+    assert obs["is_correct"] is True
+    assert obs["terminated"] is True
+
+
+@pytest.mark.asyncio
+async def test_scicode_env_wrong_answer(patch_load_tasks):
+    task = patch_load_tasks[0]
+    env = SciCodeEnv(make_instance(task))
+    await env.initialize()
+    obs = await env.step([[SubmitAnswerTool(answer="5")]])
+    assert obs["is_correct"] is False
+    assert obs["terminated"] is True


### PR DESCRIPTION
## Summary
- add new SciCode example environment with dataset loader
- mention SciCode in README
- add integration tests for SciCode environment validating correct/incorrect submissions

## Testing
- `pytest -q tests/integration/test_scicode_env.py`


------
https://chatgpt.com/codex/tasks/task_e_68448e8a193c8327b757c1810bf523c7