### PR TITLE
Add Terminal-Bench example environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.13-slim
+
+WORKDIR /app
+COPY . /app
+RUN pip install --no-cache-dir .[terminal-bench]
+
+EXPOSE 8000
+CMD ["uvicorn", "service.app:app", "--host", "0.0.0.0", "--port", "8000"]
+

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Note - this repo is under extremely active development. Hic sunt dracones, if no
 [] Red (active dev)
 [] Verilog (maturing)
 
+[] Terminal-Bench (beta)
+    - Requires Python 3.13+ and the optional `terminal-bench` extra. Install with `pip install "synth-env[terminal-bench]"`.
 ...
 
 # Development

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,9 @@ dependencies = [
 ]
 classifiers = []
 
+[project.optional-dependencies]
+terminal-bench = ['terminal-bench>=0.2.3; python_version >= "3.13"']
+
 [project.urls]
 Homepage = "https://github.com/synth-laboratories/Environments"
 

--- a/src/examples/terminal_bench/__init__.py
+++ b/src/examples/terminal_bench/__init__.py
@@ -1,0 +1,3 @@
+from .environment import TerminalBenchEnvironment
+
+__all__ = ["TerminalBenchEnvironment"]

--- a/src/examples/terminal_bench/environment.py
+++ b/src/examples/terminal_bench/environment.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any, Optional
+
+from src.environment.shared_engine import InternalObservation
+from src.stateful.core import StatefulEnvironment
+
+
+class TerminalBenchEnvironment(StatefulEnvironment):
+    """Wrapper around terminal-bench Harness for simple evaluation."""
+
+    def __init__(
+        self,
+        dataset_name: str,
+        dataset_version: str,
+        *,
+        agent_name: str = "terminus",
+        model_name: str | None = None,
+        output_path: str = "tb_runs",
+        run_id: str = "synth-run",
+        n_concurrent_trials: int = 1,
+        n_attempts: int = 1,
+        harness: Any | None = None,
+    ) -> None:
+        self.name = "TerminalBench"
+
+        if harness is None:
+            try:
+                from terminal_bench import Harness  # type: ignore
+            except Exception as exc:  # pragma: no cover - runtime import
+                raise ImportError(
+                    "terminal-bench>=0.2.3 is required for TerminalBenchEnvironment"
+                ) from exc
+
+            harness = Harness(
+                output_path=Path(output_path),
+                run_id=run_id,
+                agent_name=agent_name,
+                dataset_name=dataset_name,
+                dataset_version=dataset_version,
+                model_name=model_name,
+                n_concurrent_trials=n_concurrent_trials,
+                n_attempts=n_attempts,
+            )
+
+        self._harness = harness
+        self._results = None
+
+    async def initialize(self) -> InternalObservation:  # type: ignore[override]
+        return {"initialized": True}
+
+    async def terminate(self) -> InternalObservation:  # type: ignore[override]
+        return {"terminated": True, "results": self._serialize_results()}
+
+    def validate_tool_calls(self, tool_calls: Any) -> None:  # type: ignore[override]
+        if tool_calls:
+            raise ValueError("TerminalBenchEnvironment does not accept tool calls")
+
+    async def step(self, tool_calls: Any) -> InternalObservation:  # type: ignore[override]
+        self.validate_tool_calls(tool_calls)
+        self._results = await asyncio.to_thread(self._harness.run)
+        return {"terminated": True, "results": self._serialize_results()}
+
+    async def checkpoint(self) -> InternalObservation:  # type: ignore[override]
+        return {"results": self._serialize_results()}
+
+    def _serialize_results(self) -> Optional[dict]:
+        if self._results is None:
+            return None
+        try:
+            return self._results.model_dump()  # type: ignore[attr-defined]
+        except Exception:
+            return None

--- a/src/service/app.py
+++ b/src/service/app.py
@@ -13,6 +13,8 @@ import examples.math.environment as me
 register_environment("HendryksMath", me.HendryksMathEnv)
 import examples.verilog.environment as ve
 register_environment("Verilog", ve.VerilogEnvironment)
+import examples.terminal_bench.environment as tb
+register_environment("TerminalBench", tb.TerminalBenchEnvironment)
 
 app = FastAPI(title="Environment Service")
 

--- a/tests/unit/test_terminal_bench.py
+++ b/tests/unit/test_terminal_bench.py
@@ -1,0 +1,33 @@
+import os
+import sys
+import asyncio
+import pytest
+
+sys.path.insert(0, os.path.abspath("src"))
+sys.path.insert(0, os.path.abspath("."))
+from examples.terminal_bench.environment import TerminalBenchEnvironment
+
+class DummyResult:
+    def model_dump(self):
+        return {"ok": True}
+
+class DummyHarness:
+    def __init__(self, *a, **k):
+        pass
+    def run(self):
+        return DummyResult()
+
+def test_terminal_bench_environment_runs():
+    env = TerminalBenchEnvironment(
+        dataset_name="dummy",
+        dataset_version="0",
+        harness=DummyHarness(),
+    )
+    obs = asyncio.run(env.initialize())
+    assert obs == {"initialized": True}
+    result = asyncio.run(env.step(None))
+    assert result["terminated"] is True
+    assert result["results"] == {"ok": True}
+
+
+


### PR DESCRIPTION
## Summary
- add TerminalBenchEnvironment example
- list Terminal-Bench in README
- add optional `terminal-bench` dependency
- register TerminalBenchEnvironment with service
- add Dockerfile for running service
- add stubbed test for TerminalBenchEnvironment

## Testing
- `pytest tests/unit/test_terminal_bench.py -q`
- `pytest tests/unit/test_sokoban_failure.py -q` *(fails: XFailed during collection)*
- `PYTHONPATH=src python -m uvicorn service.app:app --port 8000 --host 127.0.0.1` *(fails: ModuleNotFoundError: No module named 'gymnasium')*


------
https://chatgpt.com/codex/tasks/task_e_68448d62f87c8327a32cd06b226a1c54