### PR TITLE
Add MiniGrid environment example

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "fastapi>=0.115.12",
     "gym-sokoban>=0.0.6",
     "gymnasium>=1.1.1",
+    "minigrid>=3.0.0",
     "uvicorn>=0.34.2",
     "ty>=0.0.1a5",
     "ruff>=0.11.10",

--- a/src/examples/minigrid/__init__.py
+++ b/src/examples/minigrid/__init__.py
@@ -1,0 +1,12 @@
+from .engine import MiniGridEngine, MiniGridEngineSnapshot, MiniGridPublicState, MiniGridPrivateState
+from .environment import MiniGridEnvironment, MiniGridTextObservationCallable, MiniGridVLMObservationCallable
+
+__all__ = [
+    "MiniGridEngine",
+    "MiniGridEngineSnapshot",
+    "MiniGridPublicState",
+    "MiniGridPrivateState",
+    "MiniGridEnvironment",
+    "MiniGridTextObservationCallable",
+    "MiniGridVLMObservationCallable",
+]

--- a/src/examples/minigrid/engine.py
+++ b/src/examples/minigrid/engine.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Tuple
+
+import gymnasium as gym
+import numpy as np
+from src.stateful.engine import StatefulEngine, StatefulEngineSnapshot
+from src.tasks.core import TaskInstance
+
+
+@dataclass
+class MiniGridPublicState:
+    mission: str
+    image: np.ndarray
+    agent_pos: Tuple[int, int]
+    agent_dir: int
+    step_count: int
+    max_steps: int
+
+
+@dataclass
+class MiniGridPrivateState:
+    reward_last: float
+    total_reward: float
+    terminated: bool
+    truncated: bool
+
+
+@dataclass
+class MiniGridEngineSnapshot(StatefulEngineSnapshot):
+    env_state: dict
+
+
+class MiniGridEngine(StatefulEngine):
+    """Thin wrapper around gymnasium-minigrid environments."""
+
+    def __init__(self, task_instance: TaskInstance):
+        self.task_instance = task_instance
+        env_id = getattr(task_instance, "env_id", "MiniGrid-Empty-8x8-v0")
+        self.env = gym.make(env_id)
+        self._total_reward = 0.0
+
+    def _build_public_state(self, obs: dict) -> MiniGridPublicState:
+        mission = obs.get("mission", "")
+        image = obs.get("image")
+        agent_pos = tuple(int(x) for x in self.env.agent_pos)
+        agent_dir = int(self.env.agent_dir)
+        step_count = int(getattr(self.env, "step_count", 0))
+        max_steps = int(getattr(self.env, "max_steps", 0))
+        return MiniGridPublicState(
+            mission=mission,
+            image=image,
+            agent_pos=agent_pos,
+            agent_dir=agent_dir,
+            step_count=step_count,
+            max_steps=max_steps,
+        )
+
+    async def _reset_engine(self) -> tuple[MiniGridPrivateState, MiniGridPublicState]:
+        obs, _ = self.env.reset()
+        self._total_reward = 0.0
+        priv = MiniGridPrivateState(
+            reward_last=0.0,
+            total_reward=0.0,
+            terminated=False,
+            truncated=False,
+        )
+        pub = self._build_public_state(obs)
+        return priv, pub
+
+    async def _step_engine(
+        self, action: int
+    ) -> tuple[MiniGridPrivateState, MiniGridPublicState]:
+        obs, reward, terminated, truncated, _ = self.env.step(action)
+        self._total_reward += float(reward)
+        priv = MiniGridPrivateState(
+            reward_last=float(reward),
+            total_reward=self._total_reward,
+            terminated=bool(terminated),
+            truncated=bool(truncated),
+        )
+        pub = self._build_public_state(obs)
+        return priv, pub
+
+    async def _serialize_engine(self) -> MiniGridEngineSnapshot:
+        state = self.env.unwrapped.state
+        return MiniGridEngineSnapshot(env_state=state)
+
+    @classmethod
+    async def _deserialize_engine(
+        cls, snapshot: MiniGridEngineSnapshot, task_instance: TaskInstance
+    ) -> "MiniGridEngine":
+        eng = cls(task_instance)
+        eng.env.reset()
+        eng.env.unwrapped.state = snapshot.env_state
+        return eng

--- a/src/examples/minigrid/environment.py
+++ b/src/examples/minigrid/environment.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+from typing import Optional, List, Union
+
+from pydantic import BaseModel
+
+from examples.minigrid.engine import (
+    MiniGridEngine,
+    MiniGridPublicState,
+    MiniGridPrivateState,
+)
+from src.environment.shared_engine import GetObservationCallable, InternalObservation
+from src.stateful.core import StatefulEnvironment
+from src.environment.tools import (
+    AbstractTool,
+    EnvToolCall,
+    ToolResult,
+    TOOL_REGISTRY,
+    register_tool,
+)
+from src.tasks.core import TaskInstance
+
+
+# -------------------------------------------------------------
+# Observation helpers
+# -------------------------------------------------------------
+
+OBJECT_TO_CHAR = {
+    0: " ",  # unseen
+    1: " ",  # empty
+    2: "#",  # wall
+    3: ".",  # floor
+    4: "D",  # door
+    5: "K",  # key
+    6: "B",  # ball
+    7: "X",  # box
+    8: "G",  # goal
+    9: "L",  # lava
+    10: "A",  # agent
+}
+
+
+def image_to_text(image) -> str:
+    rows = []
+    for row in image:
+        chars = [OBJECT_TO_CHAR.get(int(cell[0]), "?") for cell in row]
+        rows.append("".join(chars))
+    return "\n".join(rows)
+
+
+class MiniGridTextObservationCallable(GetObservationCallable):
+    async def get_observation(
+        self, pub: MiniGridPublicState, priv: MiniGridPrivateState
+    ) -> InternalObservation:
+        grid_text = image_to_text(pub.image)
+        return {
+            "grid": grid_text,
+            "mission": pub.mission,
+            "position": pub.agent_pos,
+            "direction": pub.agent_dir,
+            "step_count": pub.step_count,
+            "max_steps": pub.max_steps,
+            "reward_last": priv.reward_last,
+            "total_reward": priv.total_reward,
+            "terminated": priv.terminated,
+            "truncated": priv.truncated,
+        }
+
+
+class MiniGridVLMObservationCallable(GetObservationCallable):
+    async def get_observation(
+        self, pub: MiniGridPublicState, priv: MiniGridPrivateState
+    ) -> InternalObservation:
+        return {
+            "image": pub.image.tolist(),
+            "mission": pub.mission,
+            "position": pub.agent_pos,
+            "direction": pub.agent_dir,
+            "step_count": pub.step_count,
+            "max_steps": pub.max_steps,
+            "reward_last": priv.reward_last,
+            "total_reward": priv.total_reward,
+            "terminated": priv.terminated,
+            "truncated": priv.truncated,
+        }
+
+
+# -------------------------------------------------------------
+# Tool definition
+# -------------------------------------------------------------
+
+
+class MiniGridActionInput(BaseModel):
+    action: int
+
+
+class MiniGridInteractTool(AbstractTool):
+    name = "interact"
+    description = "Perform an action in the MiniGrid environment"
+    call_schema = MiniGridActionInput
+    result_schema = ToolResult
+
+    def __init__(self, engine: MiniGridEngine):
+        self.engine = engine
+
+    async def __call__(self, call: EnvToolCall) -> ToolResult:
+        try:
+            validated = self.call_schema(**call.args)
+            priv, pub = await self.engine._step_engine(validated.action)
+            return ToolResult(
+                ok=True,
+                payload={"public": pub, "private": priv},
+            )
+        except Exception as e:
+            return ToolResult(ok=False, error=str(e))
+
+
+class MiniGridEnvironment(StatefulEnvironment):
+    def __init__(
+        self,
+        task_instance: TaskInstance,
+        text_obs: bool = True,
+        custom_step_obs: Optional[GetObservationCallable] = None,
+        custom_ckpt_obs: Optional[GetObservationCallable] = None,
+    ):
+        self.name = "MiniGrid"
+        self.task_instance = task_instance
+        if text_obs:
+            self.custom_step_observation_callable = (
+                custom_step_obs or MiniGridTextObservationCallable()
+            )
+            self.custom_checkpoint_observation_callable = (
+                custom_ckpt_obs or MiniGridTextObservationCallable()
+            )
+        else:
+            self.custom_step_observation_callable = (
+                custom_step_obs or MiniGridVLMObservationCallable()
+            )
+            self.custom_checkpoint_observation_callable = (
+                custom_ckpt_obs or MiniGridVLMObservationCallable()
+            )
+        self.engine = MiniGridEngine(task_instance)
+
+        self._tool = MiniGridInteractTool(self.engine)
+        if self._tool.name not in TOOL_REGISTRY:
+            register_tool(self._tool)
+
+    async def initialize(self) -> InternalObservation:
+        priv, pub = await self.engine._reset_engine()
+        return await self._to_observation(
+            priv, pub, self.custom_step_observation_callable
+        )
+
+    async def terminate(self) -> InternalObservation:
+        priv = MiniGridPrivateState(
+            reward_last=0.0,
+            total_reward=self.engine._total_reward,
+            terminated=True,
+            truncated=False,
+        )
+        obs, _ = self.engine.env.reset()
+        pub = self.engine._build_public_state(obs)
+        return await self._to_observation(
+            priv, pub, self.custom_step_observation_callable
+        )
+
+    def validate_tool_calls(
+        self, tool_calls: Union[EnvToolCall, List[EnvToolCall], List[List[EnvToolCall]]]
+    ) -> EnvToolCall:
+        if isinstance(tool_calls, list):
+            if not tool_calls:
+                raise ValueError("Received empty list of tool calls")
+            if isinstance(tool_calls[0], list):
+                if not tool_calls[0]:
+                    raise ValueError("Received empty inner list of tool calls")
+                agent_call = tool_calls[0][0]
+            else:
+                agent_call = tool_calls[0]
+        else:
+            agent_call = tool_calls
+        if not isinstance(agent_call, EnvToolCall):
+            raise TypeError("tool_calls must contain EnvToolCall")
+        if agent_call.tool != "interact":
+            raise ValueError("Unknown tool: " + agent_call.tool)
+        return agent_call
+
+    async def step(
+        self, tool_calls: Union[EnvToolCall, List[EnvToolCall], List[List[EnvToolCall]]]
+    ) -> InternalObservation:
+        agent_call = self.validate_tool_calls(tool_calls)
+        result: ToolResult = await self._tool(agent_call)
+        if not result.ok or not isinstance(result.payload, dict):
+            raise RuntimeError(result.error or "Tool call failed")
+        pub: MiniGridPublicState = result.payload["public"]
+        priv: MiniGridPrivateState = result.payload["private"]
+        return await self._to_observation(
+            priv, pub, self.custom_step_observation_callable
+        )
+
+    async def checkpoint(self) -> InternalObservation:
+        snapshot = await self.engine._serialize_engine()
+        priv, pub = await self.engine._step_engine(0)  # no-op step for observation
+        obs = await self._to_observation(
+            priv, pub, self.custom_checkpoint_observation_callable
+        )
+        if isinstance(obs, dict):
+            obs["engine_snapshot_data"] = snapshot.env_state
+        return obs
+
+    async def _to_observation(
+        self,
+        priv: MiniGridPrivateState,
+        pub: MiniGridPublicState,
+        obs_cb: Optional[GetObservationCallable],
+    ) -> InternalObservation:
+        active_cb = obs_cb or MiniGridTextObservationCallable()
+        return await active_cb.get_observation(pub, priv)

--- a/src/examples/minigrid/taskset.py
+++ b/src/examples/minigrid/taskset.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict, fields
+from uuid import UUID, uuid4
+
+from src.tasks.core import TaskInstance, TaskInstanceMetadata, Impetus, Intent, Task
+
+
+minigrid_task = Task(
+    global_premises="MiniGrid navigation tasks",
+    global_constraints="",
+    global_objectives="Reach the goal square",
+    shared_env_params={},
+)
+
+
+@dataclass
+class MiniGridTaskInstanceMetadata(TaskInstanceMetadata):
+    env_id: str
+
+
+@dataclass
+class MiniGridTaskInstance(TaskInstance):
+    async def serialize(self) -> dict:
+        data = asdict(self)
+        if isinstance(data.get("id"), UUID):
+            data["id"] = str(data["id"])
+        if "intent" in data and data["intent"] is not None:
+            data["intent"]["deterministic_eval_functions"] = []
+        return data
+
+    @classmethod
+    async def deserialize(cls, data: dict) -> "MiniGridTaskInstance":
+        if "id" in data:
+            try:
+                data["id"] = UUID(str(data["id"]))
+            except Exception:
+                pass
+        if "impetus" in data:
+            data["impetus"] = Impetus(**data["impetus"])
+        if "intent" in data:
+            intent_data = data["intent"]
+            intent_data["deterministic_eval_functions"] = []
+            data["intent"] = Intent(**intent_data)
+        if "metadata" in data:
+            data["metadata"] = MiniGridTaskInstanceMetadata(**data["metadata"])
+        keep = {f.name for f in fields(cls)}
+        return cls(**{k: v for k, v in data.items() if k in keep})
+
+
+# Simple single-instance taskset
+DEFAULT_TASK_INSTANCE = MiniGridTaskInstance(
+    id=uuid4(),
+    impetus=Impetus(instructions="Navigate to the goal square."),
+    intent=Intent(rubric="Reach the goal", gold_trajectories=None, gold_state_diff={}),
+    metadata=MiniGridTaskInstanceMetadata(env_id="MiniGrid-Empty-8x8-v0"),
+    is_reproducible=True,
+    initial_engine_snapshot=None,
+)

--- a/tests/integration/test_minigrid_environment.py
+++ b/tests/integration/test_minigrid_environment.py
@@ -1,0 +1,34 @@
+import pytest
+
+from src.examples.minigrid.environment import MiniGridEnvironment
+from src.examples.minigrid.taskset import DEFAULT_TASK_INSTANCE
+from src.environment.tools import EnvToolCall
+
+
+@pytest.mark.asyncio
+async def test_minigrid_environment_text_obs():
+    env = MiniGridEnvironment(DEFAULT_TASK_INSTANCE, text_obs=True)
+    obs = await env.initialize()
+    assert "grid" in obs
+    assert isinstance(obs["grid"], str)
+
+    step_obs = await env.step(EnvToolCall(tool="interact", args={"action": 0}))
+    assert "grid" in step_obs
+
+    term_obs = await env.terminate()
+    assert term_obs["terminated"]
+
+
+@pytest.mark.asyncio
+async def test_minigrid_environment_vlm_obs():
+    env = MiniGridEnvironment(DEFAULT_TASK_INSTANCE, text_obs=False)
+    obs = await env.initialize()
+    assert "image" in obs
+    assert isinstance(obs["image"], list)
+
+    step_obs = await env.step(EnvToolCall(tool="interact", args={"action": 0}))
+    assert "image" in step_obs
+
+    cp_obs = await env.checkpoint()
+    assert "engine_snapshot_data" in cp_obs
+    await env.terminate()


### PR DESCRIPTION
## Summary
- implement MiniGrid example environment with both text and VLM observation modes
- create MiniGrid engine and task instance
- add minigrid dependency
- add integration tests for MiniGrid environment

## Testing
- `ruff format src/examples/minigrid/engine.py src/examples/minigrid/environment.py src/examples/minigrid/taskset.py tests/integration/test_minigrid_environment.py pyproject.toml`
- `ruff check src/examples/minigrid/engine.py src/examples/minigrid/environment.py src/examples/minigrid/taskset.py tests/integration/test_minigrid_environment.py`
- `pytest -q` *(fails: Could not install nmmo dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6844c31339f08327b6ccff6b594466c3