### PR TITLE
Add text-only bsuite example

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "pyboy>=2.6.0",
     "setuptools>=80.8.0",
     "psutil>=7.0.0",
+    "bsuite>=0.3.5",
 ]
 classifiers = []
 

--- a/src/examples/bsuite_text/__init__.py
+++ b/src/examples/bsuite_text/__init__.py
@@ -1,0 +1,3 @@
+from .environment import BSuiteTextEnvironment
+
+__all__ = ["BSuiteTextEnvironment"]

--- a/src/examples/bsuite_text/environment.py
+++ b/src/examples/bsuite_text/environment.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import bsuite
+
+from src.stateful.core import StatefulEnvironment
+from src.environment.shared_engine import InternalObservation
+
+
+class BSuiteTextEnvironment(StatefulEnvironment):
+    """A lightweight wrapper around bsuite environments using a text interface."""
+
+    def __init__(self, bsuite_id: str) -> None:
+        self.name = "BSuiteText"
+        self.bsuite_id = bsuite_id
+        if not hasattr(np, "int"):
+            np.int = int  # bsuite expects the deprecated np.int
+        self.env = bsuite.load_from_id(bsuite_id)
+        self._last_timestep = None
+
+    async def initialize(self) -> InternalObservation:
+        self._last_timestep = self.env.reset()
+        return self._to_observation(self._last_timestep)
+
+    async def terminate(self) -> InternalObservation:
+        return {"terminated": True}
+
+    def validate_tool_calls(self, tool_calls: Any) -> int:
+        action: Any = None
+        if isinstance(tool_calls, list):
+            first = tool_calls[0]
+            if isinstance(first, list):
+                first = first[0]
+            if isinstance(first, dict):
+                action = first.get("action")
+            else:
+                action = first
+        elif isinstance(tool_calls, dict):
+            action = tool_calls.get("action")
+        else:
+            action = tool_calls
+        if action is None:
+            raise ValueError("Missing 'action' for bsuite step call")
+        return int(action)
+
+    async def step(self, tool_calls: Any) -> InternalObservation:
+        action = self.validate_tool_calls(tool_calls)
+        self._last_timestep = self.env.step(action)
+        return self._to_observation(self._last_timestep)
+
+    async def checkpoint(self) -> InternalObservation:
+        if self._last_timestep is None:
+            return {"error": "Environment not initialized"}
+        return self._to_observation(self._last_timestep)
+
+    def _to_observation(self, timestep) -> InternalObservation:
+        obs = timestep.observation
+        if hasattr(obs, "tolist"):
+            obs = obs.tolist()
+        return {
+            "step_type": int(timestep.step_type),
+            "reward": timestep.reward,
+            "discount": timestep.discount,
+            "observation": obs,
+        }


### PR DESCRIPTION
## Summary
- add a new `bsuite_text` example wrapping DeepMind bsuite
- enable bsuite dependency in `pyproject.toml`

## Testing
- `ruff check src/examples/bsuite_text/environment.py`
- `pytest -q` *(fails: Could not install nmmo-classic-env)*

------
https://chatgpt.com/codex/tasks/task_e_6844c61d346c8327ad99dae40ae2aeb0