### PR TITLE
Add text memory gym environment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "fastapi>=0.115.12",
     "gym-sokoban>=0.0.6",
     "gymnasium>=1.1.1",
+    "memory-gym>=1.0.2",
     "uvicorn>=0.34.2",
     "ty>=0.0.1a5",
     "ruff>=0.11.10",

--- a/src/examples/memory_text/__init__.py
+++ b/src/examples/memory_text/__init__.py
@@ -1,0 +1,14 @@
+from .engine import MemoryTextEngine
+from .environment import TextMemoryGymEnv
+from .schema import MemoryTextTaskInstance, MemoryTextTaskInstanceMetadata
+from .taskset import create_memory_text_taskset
+from .tools import RecallSequenceTool
+
+__all__ = [
+    "MemoryTextEngine",
+    "TextMemoryGymEnv",
+    "MemoryTextTaskInstance",
+    "MemoryTextTaskInstanceMetadata",
+    "create_memory_text_taskset",
+    "RecallSequenceTool",
+]

--- a/src/examples/memory_text/engine.py
+++ b/src/examples/memory_text/engine.py
@@ -1,0 +1,113 @@
+import random
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+from src.stateful.engine import StatefulEngine, StatefulEngineSnapshot
+
+
+@dataclass
+class MemoryTextPublicState:
+    prompt: str
+    terminated: bool
+    correct: Optional[bool]
+
+
+@dataclass
+class MemoryTextPrivateState:
+    sequence: List[int]
+    submitted_answer: Optional[str]
+    correct: Optional[bool]
+    terminated: bool
+
+
+@dataclass
+class MemoryTextEngineSnapshot(StatefulEngineSnapshot):
+    sequence: List[int]
+    submitted_answer: Optional[str]
+    correct: Optional[bool]
+    terminated: bool
+
+
+class MemoryTextEngine(StatefulEngine):
+    def __init__(self, sequence_length: int = 5):
+        self.sequence_length = sequence_length
+        self.sequence: List[int] = []
+        self.submitted_answer: Optional[str] = None
+        self.correct: Optional[bool] = None
+        self.terminated: bool = False
+
+    async def _reset_engine(
+        self,
+    ) -> Tuple[MemoryTextPrivateState, MemoryTextPublicState]:
+        self.sequence = [random.randint(0, 9) for _ in range(self.sequence_length)]
+        self.submitted_answer = None
+        self.correct = None
+        self.terminated = False
+        priv = MemoryTextPrivateState(
+            sequence=self.sequence,
+            submitted_answer=None,
+            correct=None,
+            terminated=False,
+        )
+        pub = MemoryTextPublicState(
+            prompt="Memorize: " + " ".join(map(str, self.sequence)),
+            terminated=False,
+            correct=None,
+        )
+        return priv, pub
+
+    async def _step_engine(
+        self, answer: str
+    ) -> Tuple[MemoryTextPrivateState, MemoryTextPublicState]:
+        self.submitted_answer = answer
+        self.correct = answer.strip() == " ".join(map(str, self.sequence))
+        self.terminated = True
+        priv = MemoryTextPrivateState(
+            sequence=self.sequence,
+            submitted_answer=self.submitted_answer,
+            correct=self.correct,
+            terminated=True,
+        )
+        pub = MemoryTextPublicState(
+            prompt="Result",
+            terminated=True,
+            correct=self.correct,
+        )
+        return priv, pub
+
+    def get_current_states_for_observation(
+        self,
+    ) -> Tuple[MemoryTextPrivateState, MemoryTextPublicState]:
+        priv = MemoryTextPrivateState(
+            sequence=self.sequence,
+            submitted_answer=self.submitted_answer,
+            correct=self.correct,
+            terminated=self.terminated,
+        )
+        pub = MemoryTextPublicState(
+            prompt="Memorize: " + " ".join(map(str, self.sequence))
+            if not self.terminated
+            else "Result",
+            terminated=self.terminated,
+            correct=self.correct,
+        )
+        return priv, pub
+
+    async def _serialize_engine(self) -> MemoryTextEngineSnapshot:
+        return MemoryTextEngineSnapshot(
+            sequence=self.sequence,
+            submitted_answer=self.submitted_answer,
+            correct=self.correct,
+            terminated=self.terminated,
+        )
+
+    @classmethod
+    async def _deserialize_engine(
+        cls, snapshot: MemoryTextEngineSnapshot
+    ) -> "MemoryTextEngine":
+        engine = cls(len(snapshot.sequence))
+        engine.sequence = list(snapshot.sequence)
+        engine.submitted_answer = snapshot.submitted_answer
+        engine.correct = snapshot.correct
+        engine.terminated = snapshot.terminated
+        return engine

--- a/src/examples/memory_text/environment.py
+++ b/src/examples/memory_text/environment.py
@@ -1,0 +1,89 @@
+from typing import List, Optional
+
+from examples.memory_text.engine import (
+    MemoryTextEngine,
+    MemoryTextPrivateState,
+    MemoryTextPublicState,
+    MemoryTextEngineSnapshot,
+)
+from examples.memory_text.tools import RecallSequenceTool
+from examples.memory_text.schema import MemoryTextTaskInstance
+
+from src.environment.shared_engine import GetObservationCallable, InternalObservation
+from src.reproducibility.core import ReproducibleEnvironment
+from src.stateful.core import StatefulEnvironment
+from src.environment.tools import EnvToolCall
+
+
+class TextMemoryGymEnv(StatefulEnvironment, ReproducibleEnvironment[MemoryTextEngine]):
+    def __init__(
+        self,
+        task_instance: MemoryTextTaskInstance,
+        custom_step_obs: Optional[GetObservationCallable] = None,
+        custom_ckpt_obs: Optional[GetObservationCallable] = None,
+    ):
+        self.name = "TextMemoryGym"
+        self.task_instance = task_instance
+        self.custom_step_observation_callable = custom_step_obs
+        self.custom_checkpoint_observation_callable = custom_ckpt_obs
+        self.engine = MemoryTextEngine(task_instance.metadata.sequence_length)
+
+    async def initialize(self) -> InternalObservation:
+        priv, pub = await self.engine._reset_engine()
+        return await self._to_observation(
+            priv, pub, self.custom_step_observation_callable
+        )
+
+    async def terminate(self) -> InternalObservation:
+        return {"terminated": True}
+
+    def validate_tool_calls(self, tool_calls: List[EnvToolCall]) -> RecallSequenceTool:
+        if not tool_calls:
+            raise ValueError("No tool call provided")
+        call = tool_calls[0]
+        if not isinstance(call, RecallSequenceTool):
+            raise ValueError("Expected RecallSequenceTool")
+        return call
+
+    async def step(self, tool_calls: List[EnvToolCall]) -> InternalObservation:
+        call = self.validate_tool_calls(tool_calls)
+        priv, pub = await self.engine._step_engine(call.answer)
+        return await self._to_observation(
+            priv, pub, self.custom_step_observation_callable
+        )
+
+    async def checkpoint(self) -> InternalObservation:
+        snapshot = await self.engine._serialize_engine()
+        priv, pub = self.engine.get_current_states_for_observation()
+        obs = await self._to_observation(
+            priv, pub, self.custom_checkpoint_observation_callable
+        )
+        if isinstance(obs, dict):
+            obs["engine_snapshot_data"] = snapshot.model_dump()
+        return obs
+
+    async def _to_observation(
+        self,
+        priv: MemoryTextPrivateState,
+        pub: MemoryTextPublicState,
+        obs_cb: Optional[GetObservationCallable],
+    ) -> InternalObservation:
+        if obs_cb:
+            return await obs_cb.get_observation(pub, priv)
+        return {
+            "prompt": pub.prompt,
+            "terminated": pub.terminated,
+            "correct": pub.correct,
+        }
+
+    async def _serialize_engine(self) -> MemoryTextEngineSnapshot:
+        return await self.engine._serialize_engine()
+
+    @classmethod
+    async def _deserialize_engine(
+        cls, snapshot: MemoryTextEngineSnapshot, task_instance: MemoryTextTaskInstance
+    ) -> "TextMemoryGymEnv":
+        engine = await MemoryTextEngine._deserialize_engine(snapshot)
+        env = cls(task_instance)
+        env.engine = engine
+        return env

--- a/src/examples/memory_text/schema.py
+++ b/src/examples/memory_text/schema.py
@@ -1,0 +1,33 @@
+from dataclasses import dataclass, asdict, fields
+from uuid import UUID
+from typing import Dict, Any
+
+from src.tasks.core import TaskInstance, TaskInstanceMetadata, Impetus, Intent
+
+
+@dataclass
+class MemoryTextTaskInstanceMetadata(TaskInstanceMetadata):
+    sequence_length: int
+
+
+@dataclass
+class MemoryTextTaskInstance(TaskInstance):
+    async def serialize(self) -> Dict[str, Any]:
+        data = asdict(self)
+        if "id" in data and isinstance(data["id"], UUID):
+            data["id"] = str(data["id"])
+        return data
+
+    @classmethod
+    async def deserialize(cls, data: Dict[str, Any]) -> "MemoryTextTaskInstance":
+        if "id" in data:
+            data["id"] = UUID(str(data["id"]))
+        if "impetus" in data and isinstance(data["impetus"], dict):
+            data["impetus"] = Impetus(**data["impetus"])
+        if "intent" in data and isinstance(data["intent"], dict):
+            data["intent"] = Intent(**data["intent"])
+        if "metadata" in data and isinstance(data["metadata"], dict):
+            data["metadata"] = MemoryTextTaskInstanceMetadata(**data["metadata"])
+        field_names = {f.name for f in fields(cls)}
+        filtered = {k: v for k, v in data.items() if k in field_names}
+        return cls(**filtered)

--- a/src/examples/memory_text/taskset.py
+++ b/src/examples/memory_text/taskset.py
@@ -1,0 +1,66 @@
+from typing import List
+from uuid import uuid4
+
+from src.tasks.core import (
+    Task,
+    TaskInstanceSet,
+    TaskInstanceMetadataFilter,
+    SplitInfo,
+    Impetus,
+    Intent,
+)
+from examples.memory_text.schema import (
+    MemoryTextTaskInstance,
+    MemoryTextTaskInstanceMetadata,
+)
+
+# Global description of the task family
+TASK = Task(
+    global_premises="Memorize sequences of digits and recall them exactly.",
+    global_constraints="",
+    global_objectives="Correctly repeat the shown sequence.",
+    shared_env_params={},
+)
+
+
+class SequenceLengthFilter(TaskInstanceMetadataFilter):
+    def __init__(self, length: int) -> None:
+        self.length = length
+
+    def __call__(self, instance: MemoryTextTaskInstance) -> bool:
+        return getattr(instance.metadata, "sequence_length", None) == self.length
+
+
+async def create_memory_text_taskset(
+    num_instances: int = 20, sequence_length: int = 5
+) -> TaskInstanceSet:
+    """Generate a simple TaskInstanceSet for TextMemoryGym."""
+    instances: List[MemoryTextTaskInstance] = []
+    for _ in range(num_instances):
+        impetus = Impetus(instructions="Recall the digits in order.")
+        intent = Intent(rubric={"goal": "Repeat the sequence"})
+        metadata = MemoryTextTaskInstanceMetadata(sequence_length=sequence_length)
+        instance = MemoryTextTaskInstance(
+            id=uuid4(),
+            impetus=impetus,
+            intent=intent,
+            metadata=metadata,
+            is_reproducible=True,
+            initial_engine_snapshot=None,
+        )
+        instances.append(instance)
+
+    # Simple 80/10/10 split
+    n = len(instances)
+    val_ids = {inst.id for inst in instances[int(0.8 * n) : int(0.9 * n)]}
+    test_ids = {inst.id for inst in instances[int(0.9 * n) :]}
+    split = SplitInfo(
+        val_instance_ids=val_ids, test_instance_ids=test_ids, _is_split_defined=True
+    )
+
+    return TaskInstanceSet(
+        name="TextMemoryGym TaskSet",
+        description="Digit sequence recall tasks.",
+        instances=instances,
+        split_info=split,
+    )

--- a/src/examples/memory_text/tools.py
+++ b/src/examples/memory_text/tools.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+from src.environment.tools import EnvToolCall
+
+
+@dataclass
+class RecallSequenceTool(EnvToolCall):
+    answer: str
+
+    def __str__(self) -> str:
+        preview = self.answer[:50]
+        if len(self.answer) > 50:
+            preview += "..."
+        return f"RecallSequenceTool(answer='{preview}')"

--- a/src/service/app.py
+++ b/src/service/app.py
@@ -1,4 +1,6 @@
-import sys; print(f"SYS.PATH IN APP.PY: {sys.path}")
+import sys
+
+print(f"SYS.PATH IN APP.PY: {sys.path}")
 
 from fastapi import FastAPI
 from service.registry import list_supported_env_types, register_environment
@@ -6,20 +8,29 @@ from service.core_routes import api_router
 
 # Register environments at import time (so registry is populated immediately)
 import examples.sokoban.environment as sok
+
 register_environment("Sokoban", sok.SokobanEnvironment)
 import examples.crafter_classic.environment as cc
+
 register_environment("CrafterClassic", cc.CrafterClassicEnvironment)
 import examples.math.environment as me
+
 register_environment("HendryksMath", me.HendryksMathEnv)
 import examples.verilog.environment as ve
+
 register_environment("Verilog", ve.VerilogEnvironment)
+import examples.memory_text.environment as mt
+
+register_environment("TextMemoryGym", mt.TextMemoryGymEnv)
 
 app = FastAPI(title="Environment Service")
+
 
 @app.on_event("startup")
 async def startup_event():
     # Ready to serve
     pass
+
 
 # Mount the main API router under /env
 app.include_router(api_router, prefix="/env", tags=["env"])


### PR DESCRIPTION
## Summary
- support text-only Memory Gym via `TextMemoryGymEnv`
- register new environment in the service
- add `memory-gym` dependency
- include a simple task set for TextMemoryGym

## Testing
- `ruff format src/examples/memory_text/*.py src/service/app.py pyproject.toml`
- `pytest -q` *(fails: Could not find a version that satisfies nmmo>=2.1.2)*

------
https://chatgpt.com/codex/tasks/task_e_6844c62a5a408327aa35821b55da3b5e