### PR TITLE
Add Treasure Hunter environment example

### DIFF
--- a/src/examples/treasure_hunter/__init__.py
+++ b/src/examples/treasure_hunter/__init__.py
@@ -1,0 +1,3 @@
+from .environment import TreasureHunterEnvironment
+
+__all__ = ["TreasureHunterEnvironment"]

--- a/src/examples/treasure_hunter/engine.py
+++ b/src/examples/treasure_hunter/engine.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Tuple, Dict, Any, Optional
+
+from src.stateful.engine import StatefulEngine, StatefulEngineSnapshot
+from src.tasks.core import TaskInstance
+from src.reproducibility.core import IReproducibleEngine
+
+
+@dataclass
+class TreasureHunterPublicState:
+    position: Tuple[int, int]
+    has_treasure: bool
+    step_count: int
+    max_steps: int
+    error_info: Optional[str] = None
+
+
+@dataclass
+class TreasureHunterPrivateState:
+    reward_last: float
+    total_reward: float
+    terminated: bool
+    truncated: bool
+
+
+@dataclass
+class TreasureHunterEngineSnapshot(StatefulEngineSnapshot):
+    state: Dict[str, Any]
+
+
+class TreasureHunterEngine(StatefulEngine, IReproducibleEngine):
+    """Simple text world engine where the agent must find a treasure."""
+
+    def __init__(self, task_instance: TaskInstance):
+        self.task_instance = task_instance
+        self.grid_size = getattr(task_instance.metadata, "grid_size", 5)
+        self.max_steps = getattr(task_instance.metadata, "max_steps", 20)
+        self.treasure_pos = getattr(task_instance.metadata, "treasure_pos", (self.grid_size - 1, self.grid_size - 1))
+        self._total_reward = 0.0
+        self._step_count = 0
+        self.position: Tuple[int, int] = (0, 0)
+        self.has_treasure = False
+        self.terminated = False
+        self.truncated = False
+
+    def _build_public_state(self) -> TreasureHunterPublicState:
+        return TreasureHunterPublicState(
+            position=self.position,
+            has_treasure=self.has_treasure,
+            step_count=self._step_count,
+            max_steps=self.max_steps,
+        )
+
+    def _build_private_state(self, reward: float) -> TreasureHunterPrivateState:
+        return TreasureHunterPrivateState(
+            reward_last=reward,
+            total_reward=self._total_reward,
+            terminated=self.terminated,
+            truncated=self.truncated,
+        )
+
+    async def _reset_engine(self) -> tuple[TreasureHunterPrivateState, TreasureHunterPublicState]:
+        self._total_reward = 0.0
+        self._step_count = 0
+        self.position = (0, 0)
+        self.has_treasure = False
+        self.terminated = False
+        self.truncated = False
+        priv = self._build_private_state(0.0)
+        pub = self._build_public_state()
+        return priv, pub
+
+    async def _step_engine(self, command: str) -> tuple[TreasureHunterPrivateState, TreasureHunterPublicState]:
+        if self.terminated:
+            return self._build_private_state(0.0), self._build_public_state()
+
+        reward = 0.0
+        cmd = command.lower().strip()
+        x, y = self.position
+        if cmd == "north" and y > 0:
+            y -= 1
+        elif cmd == "south" and y < self.grid_size - 1:
+            y += 1
+        elif cmd == "west" and x > 0:
+            x -= 1
+        elif cmd == "east" and x < self.grid_size - 1:
+            x += 1
+        elif cmd == "take" and (x, y) == self.treasure_pos and not self.has_treasure:
+            self.has_treasure = True
+            reward = 1.0
+            self.terminated = True
+        else:
+            # invalid command or no effect
+            pass
+
+        self.position = (x, y)
+        self._step_count += 1
+        self._total_reward += reward
+        if self._step_count >= self.max_steps and not self.terminated:
+            self.terminated = True
+            self.truncated = True
+
+        return self._build_private_state(reward), self._build_public_state()
+
+    async def _serialize_engine(self) -> TreasureHunterEngineSnapshot:
+        state = {
+            "position": self.position,
+            "has_treasure": self.has_treasure,
+            "step_count": self._step_count,
+            "total_reward": self._total_reward,
+            "terminated": self.terminated,
+            "truncated": self.truncated,
+        }
+        return TreasureHunterEngineSnapshot(state=state)
+
+    @classmethod
+    async def _deserialize_engine(cls, snapshot: TreasureHunterEngineSnapshot, task_instance: TaskInstance) -> "TreasureHunterEngine":
+        eng = cls(task_instance)
+        state = snapshot.state
+        eng.position = tuple(state.get("position", (0, 0)))
+        eng.has_treasure = state.get("has_treasure", False)
+        eng._step_count = state.get("step_count", 0)
+        eng._total_reward = state.get("total_reward", 0.0)
+        eng.terminated = state.get("terminated", False)
+        eng.truncated = state.get("truncated", False)
+        return eng

--- a/src/examples/treasure_hunter/environment.py
+++ b/src/examples/treasure_hunter/environment.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+from typing import Optional, Any, Dict, List, Union
+from pydantic import BaseModel, Field
+from dataclasses import asdict
+
+from .engine import (
+    TreasureHunterEngine,
+    TreasureHunterPublicState,
+    TreasureHunterPrivateState,
+    TreasureHunterEngineSnapshot,
+)
+from .schema import TreasureHunterTaskInstance
+from src.environment.shared_engine import GetObservationCallable, InternalObservation
+from src.stateful.core import StatefulEnvironment
+from src.reproducibility.core import ReproducibleEnvironment
+from src.tasks.core import TaskInstance
+from src.environment.tools import AbstractTool, EnvToolCall, ToolResult, TOOL_REGISTRY, register_tool
+
+
+class CommandInput(BaseModel):
+    command: str = Field(..., description="Text command like 'north' or 'take'")
+
+
+class CommandTool(AbstractTool):
+    name = "command"
+    description = "Execute a text command in the treasure hunter world"
+    call_schema = CommandInput
+    result_schema = ToolResult
+
+    def __init__(self, engine: TreasureHunterEngine):
+        self.engine = engine
+
+    async def __call__(self, call: EnvToolCall) -> ToolResult:
+        try:
+            validated = self.call_schema(**call.args)
+            priv, pub = await self.engine._step_engine(validated.command)
+            return ToolResult(ok=True, payload={"public": asdict(pub), "private": asdict(priv)})
+        except Exception as e:
+            pub = self.engine._build_public_state()
+            return ToolResult(ok=False, error=str(e), payload={"public": asdict(pub)})
+
+
+class TreasureObservationCallable(GetObservationCallable):
+    async def get_observation(self, pub: TreasureHunterPublicState, priv: TreasureHunterPrivateState) -> InternalObservation:
+        obs = asdict(pub)
+        obs.update({
+            "reward_last": priv.reward_last,
+            "total_reward": priv.total_reward,
+            "terminated": priv.terminated,
+            "truncated": priv.truncated,
+        })
+        return obs
+
+
+class TreasureHunterEnvironment(StatefulEnvironment, ReproducibleEnvironment[TreasureHunterEngine]):
+    def __init__(self, task_instance: TreasureHunterTaskInstance, custom_step_obs: Optional[GetObservationCallable] = None, custom_ckpt_obs: Optional[GetObservationCallable] = None):
+        self.name = "TreasureHunter"
+        self.task_instance = task_instance
+        self.custom_step_observation_callable = custom_step_obs or TreasureObservationCallable()
+        self.custom_checkpoint_observation_callable = custom_ckpt_obs or TreasureObservationCallable()
+        self.engine = TreasureHunterEngine(task_instance)
+
+        self._command_tool = CommandTool(self.engine)
+        if self._command_tool.name not in TOOL_REGISTRY:
+            register_tool(self._command_tool)
+
+    async def initialize(self) -> InternalObservation:
+        priv, pub = await self.engine._reset_engine()
+        return await self._to_observation(priv, pub, self.custom_step_observation_callable)
+
+    async def terminate(self) -> InternalObservation:
+        self.engine.terminated = True
+        priv, pub = self.engine._build_private_state(0.0), self.engine._build_public_state()
+        return await self._to_observation(priv, pub, self.custom_step_observation_callable)
+
+    def validate_tool_calls(self, tool_calls: Union[EnvToolCall, List[EnvToolCall], List[List[EnvToolCall]]]) -> EnvToolCall:
+        if isinstance(tool_calls, list):
+            if not tool_calls:
+                raise ValueError("Empty tool calls")
+            first = tool_calls[0]
+            if isinstance(first, list):
+                first = first[0]
+            call = first
+        else:
+            call = tool_calls
+        if not isinstance(call, EnvToolCall):
+            raise TypeError("tool call must be EnvToolCall")
+        if call.tool != "command":
+            raise ValueError("Unknown tool")
+        return call
+
+    async def step(self, tool_calls: Union[EnvToolCall, List[EnvToolCall], List[List[EnvToolCall]]]) -> InternalObservation:
+        call = self.validate_tool_calls(tool_calls)
+        result = await self._command_tool(call)
+        if result.ok:
+            priv = TreasureHunterPrivateState(**result.payload["private"])
+            pub = TreasureHunterPublicState(**result.payload["public"])
+        else:
+            priv, pub = self.engine._build_private_state(0.0), self.engine._build_public_state()
+            if pub.error_info is None:
+                pub.error_info = result.error
+        return await self._to_observation(priv, pub, self.custom_step_observation_callable)
+
+    async def checkpoint(self) -> InternalObservation:
+        snapshot = await self.engine._serialize_engine()
+        priv, pub = self.engine._build_private_state(0.0), self.engine._build_public_state()
+        obs = await self._to_observation(priv, pub, self.custom_checkpoint_observation_callable)
+        if isinstance(obs, dict):
+            obs["engine_snapshot_data"] = snapshot.state
+        return obs
+
+    async def _to_observation(self, priv: TreasureHunterPrivateState, pub: TreasureHunterPublicState, obs_cb: Optional[GetObservationCallable]) -> InternalObservation:
+        cb = obs_cb or TreasureObservationCallable()
+        return await cb.get_observation(pub, priv)
+
+    async def _serialize_engine(self) -> TreasureHunterEngineSnapshot:
+        return await self.engine._serialize_engine()
+
+    @classmethod
+    async def _deserialize_engine(cls, snapshot: TreasureHunterEngineSnapshot, task_instance: TaskInstance) -> "TreasureHunterEnvironment":
+        eng = await TreasureHunterEngine._deserialize_engine(snapshot, task_instance)
+        env = cls(task_instance)
+        env.engine = eng
+        return env

--- a/src/examples/treasure_hunter/schema.py
+++ b/src/examples/treasure_hunter/schema.py
@@ -1,0 +1,38 @@
+from dataclasses import dataclass, asdict, fields
+from typing import Tuple, Optional, Dict, Any
+from uuid import UUID
+
+from src.tasks.core import TaskInstance, TaskInstanceMetadata, Impetus, Intent
+
+
+@dataclass
+class TreasureHunterTaskInstanceMetadata(TaskInstanceMetadata):
+    grid_size: int = 5
+    max_steps: int = 20
+    treasure_pos: Tuple[int, int] = (4, 4)
+
+
+@dataclass
+class TreasureHunterTaskInstance(TaskInstance):
+    async def serialize(self) -> Dict[str, Any]:
+        data = asdict(self)
+        if isinstance(data.get("id"), UUID):
+            data["id"] = str(data["id"])
+        return data
+
+    @classmethod
+    async def deserialize(cls, data: Dict[str, Any]) -> "TreasureHunterTaskInstance":
+        if "id" in data:
+            try:
+                data["id"] = UUID(str(data["id"]))
+            except Exception:
+                pass
+        if "impetus" in data and isinstance(data["impetus"], dict):
+            data["impetus"] = Impetus(**data["impetus"])
+        if "intent" in data and isinstance(data["intent"], dict):
+            data["intent"] = Intent(**data["intent"])
+        if "metadata" in data and isinstance(data["metadata"], dict):
+            data["metadata"] = TreasureHunterTaskInstanceMetadata(**data["metadata"])
+        allowed = {f.name for f in fields(cls)}
+        filtered = {k: v for k, v in data.items() if k in allowed}
+        return cls(**filtered)

--- a/src/examples/treasure_hunter/taskset.py
+++ b/src/examples/treasure_hunter/taskset.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+from dataclasses import dataclass
+import uuid
+
+from src.tasks.core import Task, TaskInstance, Impetus, Intent, TaskInstanceMetadata
+from .schema import TreasureHunterTaskInstance, TreasureHunterTaskInstanceMetadata
+
+TASK = Task(
+    global_premises="Simple text world where the goal is to find a hidden treasure.",
+    global_constraints="You can move north, south, east, west and take the treasure when found.",
+    global_objectives="Retrieve the treasure in as few steps as possible.",
+    shared_env_params={},
+)
+
+@dataclass
+class _DefaultMetadata(TreasureHunterTaskInstanceMetadata):
+    pass
+
+INSTANCE = TreasureHunterTaskInstance(
+    id=uuid.UUID("00000000-0000-0000-0000-000000000001"),
+    impetus=Impetus(instructions="Find the treasure."),
+    intent=Intent(rubric="Treasure obtained", gold_trajectories=None, gold_state_diff={"has_treasure": True}),
+    metadata=_DefaultMetadata(),
+    is_reproducible=True,
+    initial_engine_snapshot=None,
+)

--- a/src/examples/treasure_hunter/units/test_integration.py
+++ b/src/examples/treasure_hunter/units/test_integration.py
@@ -1,0 +1,27 @@
+import sys
+from pathlib import Path
+import pytest
+
+# Ensure the repo's src directory is importable regardless of pytest invocation
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from src.examples.treasure_hunter.environment import TreasureHunterEnvironment
+from src.examples.treasure_hunter.taskset import INSTANCE
+from src.environment.tools import EnvToolCall
+
+@pytest.mark.asyncio
+async def test_treasure_hunter_episode():
+    env = TreasureHunterEnvironment(INSTANCE)
+    obs = await env.initialize()
+    assert obs["position"] == (0, 0)
+    # Move east 4 times and south 4 times to reach treasure
+    for _ in range(4):
+        obs = await env.step(EnvToolCall(tool="command", args={"command": "east"}))
+    for _ in range(4):
+        obs = await env.step(EnvToolCall(tool="command", args={"command": "south"}))
+    assert obs["position"] == (4, 4)
+    assert not obs["terminated"]
+    obs = await env.step(EnvToolCall(tool="command", args={"command": "take"}))
+    assert obs["terminated"]
+    assert obs["has_treasure"] is True
+    assert obs["total_reward"] == pytest.approx(1.0)


### PR DESCRIPTION
## Summary
- add simple text-based Treasure Hunter engine and environment
- define task schema and a default task instance
- include integration test for agent workflow
- fix import path setup in integration test

## Testing
- `pip install pytest-asyncio`
- `PYTHONPATH=src:. pytest -q src/examples/treasure_hunter/units/test_integration.py`


------
https://chatgpt.com/codex/tasks/task_e_6844caa2a904832789be6c14884f5a79