### PR TITLE
Fix: Multiple environment service bugs - empty observations and seria…

### DIFF
--- a/src/synth_env/examples/crafter_classic/environment.py
+++ b/src/synth_env/examples/crafter_classic/environment.py
@@ -150,27 +150,48 @@ class CrafterClassicEnvironment(
     # ────────────────────────────────────────────────────────────────────
 
     def validate_tool_calls(
-        self, tool_calls: Union[EnvToolCall, List[EnvToolCall], List[List[EnvToolCall]]]
+        self, tool_calls: Union[EnvToolCall, List[EnvToolCall], List[List[EnvToolCall]], List[Dict[str, Any]], Dict[str, Any]]
     ) -> EnvToolCall:
         # Normalize and validate to a single EnvToolCall (same as Sokoban)
+        raw_call_data: Dict[str, Any]
+        
         if isinstance(tool_calls, list):
             if not tool_calls:
                 raise ValueError("Received empty list of tool calls.")
-            if isinstance(tool_calls[0], list):
-                if not tool_calls[0]:
+            first_item = tool_calls[0]
+            if isinstance(first_item, list):
+                if not first_item:
                     raise ValueError("Received empty inner list of tool calls.")
-                agent_call = tool_calls[0][0]
+                raw_call_data = first_item[0]
+            elif isinstance(first_item, dict):
+                raw_call_data = first_item
+            elif isinstance(first_item, EnvToolCall):
+                agent_call = first_item
+                if agent_call.tool != "interact":
+                    raise ValueError(f"Unknown tool: {agent_call.tool}. Expected 'interact'.")
+                return agent_call
             else:
-                agent_call = tool_calls[0]
+                raise TypeError(f"Unexpected type in tool_calls list: {type(first_item)}")
+        elif isinstance(tool_calls, dict):
+            raw_call_data = tool_calls
         elif isinstance(tool_calls, EnvToolCall):
             agent_call = tool_calls
+            if agent_call.tool != "interact":
+                raise ValueError(f"Unknown tool: {agent_call.tool}. Expected 'interact'.")
+            return agent_call
         else:
             raise TypeError(f"Unexpected type for tool_calls: {type(tool_calls)}")
 
-        if not isinstance(agent_call, EnvToolCall):
-            raise TypeError(f"Processed call is not EnvToolCall: {type(agent_call)}")
-        if agent_call.tool != "interact":
-            raise ValueError(f"Unknown tool: {agent_call.tool}. Expected 'interact'.")
+        if not isinstance(raw_call_data, dict):
+            raise TypeError(f"Processed call data is not a dict: {type(raw_call_data)}")
+
+        # Convert dict to EnvToolCall instance (same as Sokoban)
+        tool_name = raw_call_data.get("tool")
+        tool_args = raw_call_data.get("args", {})
+        if tool_name != "interact":
+            raise ValueError(f"Unknown tool: {tool_name}. Expected 'interact'.")
+
+        agent_call = EnvToolCall(tool=tool_name, args=tool_args)
         return agent_call
 
     async def step(

--- a/src/synth_env/examples/sokoban/agent_demos/test_synth_react_service.py
+++ b/src/synth_env/examples/sokoban/agent_demos/test_synth_react_service.py
@@ -14,6 +14,279 @@ from synth_ai.zyk import LM
 # Demo: drive Sokoban via FastAPI service endpoints
 
 
+# === UNIT TESTS FOR SERVICE INTEGRATION ===
+
+def create_valid_snapshot():
+    """Create a valid Sokoban snapshot using proper room generation"""
+    from synth_env.examples.sokoban.engine_helpers.room_utils import generate_room
+    
+    room_fixed, room_state, _, _ = generate_room(
+        dim=(5, 5),
+        initial_seed=42,
+        num_boxes=1,
+        search_depth=15
+    )
+    
+    return {
+        "dim_room": [5, 5],
+        "room_fixed": room_fixed.tolist(),
+        "room_state": room_state.tolist(),
+        "boxes_on_target": 0,
+        "max_steps": 50,
+        "num_boxes": 1
+    }
+
+
+@pytest.mark.anyio
+async def test_sokoban_service_new_api():
+    """Test the new /env/Sokoban/initialize API - verifies the fix works"""
+    async with AsyncClient(base_url="http://localhost:8000", timeout=30.0) as client:
+        # 1) Health check
+        health = await client.get("/health")
+        assert health.status_code == 200
+        supported = health.json()["supported_environments"]
+        assert "Sokoban" in supported
+        print("✅ Health check passed")
+
+        # 2) Initialize a Sokoban instance using the new API with generated room
+        snapshot = create_valid_snapshot()
+        resp = await client.post(
+            "/env/Sokoban/initialize",
+            json={"initial_state": snapshot, "config": {}}
+        )
+        print(f"Initialize response status: {resp.status_code}")
+        print(f"Initialize response: {resp.text}")
+        assert resp.status_code == 200
+        
+        init_data = resp.json()
+        instance_id = init_data["env_id"]
+        initial_obs = init_data["observation"]
+        print(f"✅ Created instance: {instance_id}")
+        
+        # 3) Critical test: Verify observation is NOT empty (this was the bug!)
+        assert len(initial_obs) > 0, "Initial observation should not be empty!"
+        assert "room_text" in initial_obs, "Should have room_text in observation"
+        assert "player_position" in initial_obs, "Should have player_position in observation"
+        print(f"✅ Observation has {len(initial_obs)} keys: {list(initial_obs.keys())}")
+        
+        # 4) Take a few steps to verify step observations are also not empty
+        for step_num in range(3):
+            # Try moving right (action 8)
+            step_resp = await client.post(
+                "/env/Sokoban/step",
+                json={
+                    "env_id": instance_id,
+                    "request_id": f"test_step_{step_num}",
+                    "action": {
+                        "tool_calls": [{"tool": "interact", "args": {"action": 8}}]
+                    }
+                }
+            )
+            assert step_resp.status_code == 200
+            
+            step_data = step_resp.json()
+            obs_data = step_data.get("observation", {})
+            
+            # Critical test: Step observations should NOT be empty
+            assert len(obs_data) > 0, f"Step {step_num+1} observation should not be empty!"
+            assert "room_text" in obs_data, f"Step {step_num+1} should have room_text"
+            
+            print(f"✅ Step {step_num+1}: Observation has {len(obs_data)} keys")
+            print(f"   Boxes on target: {obs_data.get('boxes_on_target', 0)}")
+            print(f"   Steps taken: {obs_data.get('steps_taken', 0)}")
+            
+            if obs_data.get("terminated"):
+                print(f"Game terminated at step {step_num+1}")
+                break
+
+        # 5) Terminate the instance
+        term_resp = await client.post(
+            "/env/Sokoban/terminate",
+            json={"env_id": instance_id}
+        )
+        assert term_resp.status_code == 200
+        print("✅ Instance terminated successfully")
+
+
+@pytest.mark.anyio
+async def test_sokoban_service_legacy_api():
+    """Test the legacy /Sokoban/create API - verifies both APIs work"""
+    async with AsyncClient(base_url="http://localhost:8000", timeout=30.0) as client:
+        # 1) Create using legacy API with generated room
+        snapshot = create_valid_snapshot()
+        resp = await client.post(
+            "/Sokoban/create",
+            json={"initial_state": snapshot}
+        )
+        print(f"Legacy create response status: {resp.status_code}")
+        
+        if resp.status_code == 200:
+            create_data = resp.json()
+            instance_id = create_data["instance_id"]
+            print(f"✅ Created legacy instance: {instance_id}")
+            
+            # 2) Reset to get initial observation
+            reset_resp = await client.post(f"/Sokoban/{instance_id}/reset")
+            assert reset_resp.status_code == 200
+            
+            obs = reset_resp.json()
+            private = obs["private"]
+            public = obs["public"]
+            
+            # Verify observations are not empty
+            assert len(private) > 0, "Private observation should not be empty!"
+            assert len(public) > 0, "Public observation should not be empty!"
+            assert "room_text" in public, "Should have room_text in public observation"
+            
+            print(f"✅ Legacy API: Public obs has {len(public)} keys, Private obs has {len(private)} keys")
+            print(f"   Initial state: Boxes on target: {public.get('boxes_on_target', 0)}")
+            
+            # 3) Take a step using legacy API
+            step_resp = await client.post(
+                f"/Sokoban/{instance_id}/step",
+                json=[{"tool": "interact", "args": {"action": 8}}]
+            )
+            assert step_resp.status_code == 200
+            
+            step_obs = step_resp.json()
+            step_private = step_obs["private"]
+            step_public = step_obs["public"]
+            
+            # Critical test: Step observations should NOT be empty
+            assert len(step_private) > 0, "Step private observation should not be empty!"
+            assert len(step_public) > 0, "Step public observation should not be empty!"
+            print(f"✅ Legacy step: Public obs has {len(step_public)} keys, Private obs has {len(step_private)} keys")
+            
+            # 4) Terminate using legacy API
+            term_resp = await client.post(f"/Sokoban/{instance_id}/terminate")
+            assert term_resp.status_code == 200
+            print("✅ Legacy instance terminated successfully")
+
+
+@pytest.mark.anyio
+async def test_generated_room():
+    """Test with a generated room using proper room generation"""
+    from synth_env.examples.sokoban.engine_helpers.room_utils import generate_room
+    
+    # Generate a simple room
+    room_fixed, room_state, _, _ = generate_room(
+        dim=(6, 6),
+        initial_seed=123,
+        num_boxes=2,
+        search_depth=20
+    )
+    
+    snapshot = {
+        "dim_room": [6, 6],
+        "room_fixed": room_fixed.tolist(),
+        "room_state": room_state.tolist(),
+        "boxes_on_target": 0,
+        "max_steps": 100,
+        "num_boxes": 2
+    }
+    
+    async with AsyncClient(base_url="http://localhost:8000", timeout=30.0) as client:
+        # Initialize with generated room
+        resp = await client.post(
+            "/env/Sokoban/initialize",
+            json={"initial_state": snapshot, "config": {}}
+        )
+        print(f"Generated room initialize status: {resp.status_code}")
+        
+        if resp.status_code == 200:
+            init_data = resp.json()
+            instance_id = init_data["env_id"]
+            obs = init_data["observation"]
+            
+            # Critical test: Verify observation is not empty
+            assert len(obs) > 0, "Generated room observation should not be empty!"
+            assert "room_text" in obs, "Should have room_text in observation"
+            assert obs["num_boxes"] == 2, f"Should have 2 boxes, got {obs.get('num_boxes', 0)}"
+            
+            print(f"✅ Created instance with generated room: {instance_id}")
+            print(f"✅ Observation has {len(obs)} keys including: {list(obs.keys())}")
+            
+            # Show the room
+            if "room_text" in obs:
+                print(f"🎮 Generated Room ({obs['num_boxes']} boxes):")
+                print(obs["room_text"])
+            
+            # Terminate
+            term_resp = await client.post(
+                "/env/Sokoban/terminate",
+                json={"env_id": instance_id}
+            )
+            assert term_resp.status_code == 200
+            print("✅ Generated room test completed successfully")
+
+
+@pytest.mark.anyio
+async def test_observation_content_validation():
+    """Test that observations contain expected content structure"""
+    async with AsyncClient(base_url="http://localhost:8000", timeout=30.0) as client:
+        snapshot = create_valid_snapshot()
+        
+        # Initialize
+        resp = await client.post(
+            "/env/Sokoban/initialize",
+            json={"initial_state": snapshot, "config": {}}
+        )
+        assert resp.status_code == 200
+        
+        init_data = resp.json()
+        instance_id = init_data["env_id"]
+        obs = init_data["observation"]
+        
+        # Test specific observation structure
+        required_keys = ["room_text", "player_position", "boxes_on_target", "steps_taken", "num_boxes"]
+        for key in required_keys:
+            assert key in obs, f"Missing required key: {key}"
+        
+        # Test data types
+        assert isinstance(obs["player_position"], list), "player_position should be a list"
+        assert isinstance(obs["boxes_on_target"], int), "boxes_on_target should be an int"
+        assert isinstance(obs["steps_taken"], int), "steps_taken should be an int"
+        assert isinstance(obs["room_text"], str), "room_text should be a string"
+        assert len(obs["room_text"]) > 0, "room_text should not be empty"
+        
+        print(f"✅ Observation structure validation passed")
+        print(f"   Player position: {obs['player_position']}")
+        print(f"   Boxes on target: {obs['boxes_on_target']}/{obs['num_boxes']}")
+        print(f"   Steps taken: {obs['steps_taken']}")
+        print(f"   Room text length: {len(obs['room_text'])} characters")
+        
+        # Take a step and verify the observation still has proper structure
+        step_resp = await client.post(
+            "/env/Sokoban/step",
+            json={
+                "env_id": instance_id,
+                "request_id": "validation_step",
+                "action": {
+                    "tool_calls": [{"tool": "interact", "args": {"action": 8}}]
+                }
+            }
+        )
+        assert step_resp.status_code == 200
+        
+        step_data = step_resp.json()
+        step_obs = step_data.get("observation", {})
+        
+        # Verify step observation structure
+        for key in required_keys:
+            assert key in step_obs, f"Missing required key in step observation: {key}"
+        
+        # Verify steps_taken increased
+        assert step_obs["steps_taken"] > obs["steps_taken"], "steps_taken should increase after step"
+        
+        print(f"✅ Step observation structure validation passed")
+        print(f"   Steps taken after step: {step_obs['steps_taken']}")
+        
+        # Cleanup
+        await client.post("/env/Sokoban/terminate", json={"env_id": instance_id})
+
+
+# === END UNIT TESTS ===
+
 # HTTP-mode formatting for service-based observations
 def format_obs_http(public: dict, private: dict, total_boxes: int) -> str:
     room_text = public.get("room_text") or public.get("room_text_final", "")


### PR DESCRIPTION
…lization

- Fixed core bug in step_env where result.get('observation', {}) always returned {}
- Root cause: StatefulEnvironment.step() returns observation dict directly, not wrapped
- Updated response formatting to treat result as observation itself
- Added numpy type conversion for JSON serialization (fixes CrafterClassic)
- Fixed CrafterClassic validate_tool_calls to handle dict-to-EnvToolCall conversion
- Added comprehensive unit tests to verify fixes work correctly
- Added fallback in-memory storage for numpy serialization issues

Verified working environments:
✅ Sokoban: Full observations with room text, player position, etc. ✅ CrafterClassic: Rich 14-key observations with inventory, achievements, maps, etc. ✅ Both new API (/env/{Environment}/) and legacy API work correctly ✅ All tests pass with non-empty, properly serialized observations